### PR TITLE
refactor: DateRules. Keep method names consistent

### DIFF
--- a/src/Dates/DateQueries.php
+++ b/src/Dates/DateQueries.php
@@ -8,14 +8,14 @@ trait DateQueries
 {
     use SetUpDateRules;
 
-    public function from(string $date): Builder
+    public function createdFrom(string $date): Builder
     {
-        return $this->dateRules($this)->from($date);
+        return $this->dateRules($this)->createdFrom($date);
     }
 
-    public function to(string $date): Builder
+    public function createdTo(string $date): Builder
     {
-        return $this->dateRules($this)->to($date);
+        return $this->dateRules($this)->createdTo($date);
     }
 
     public function modifiedFrom(string $date): Builder

--- a/src/Dates/DateRules.php
+++ b/src/Dates/DateRules.php
@@ -19,12 +19,12 @@ class DateRules implements Rules
         return new self($builder);
     }
 
-    public function from(string $date): Builder
+    public function createdFrom(string $date): Builder
     {
         return $this->builder->where('created_at', '>=', $date);
     }
 
-    public function to(string $date): Builder
+    public function createdTo(string $date): Builder
     {
         return $this->builder->whereDate('created_at', '<=', $date);
     }

--- a/src/Dates/DateScopes.php
+++ b/src/Dates/DateScopes.php
@@ -14,14 +14,14 @@ trait DateScopes
 {
     use SetUpDateRules;
 
-    public function scopeFrom(Builder $query, string $date): Builder
+    public function scopeCreatedFrom(Builder $query, string $date): Builder
     {
-        return $this->dateRules($query)->from($date);
+        return $this->dateRules($query)->createdFrom($date);
     }
 
-    public function scopeTo(Builder $query, string $date): Builder
+    public function scopeCreatedTo(Builder $query, string $date): Builder
     {
-        return $this->dateRules($query)->to($date);
+        return $this->dateRules($query)->createdTo($date);
     }
 
     public function scopeModifiedFrom(Builder $query, string $date): Builder

--- a/src/Dates/Rules.php
+++ b/src/Dates/Rules.php
@@ -6,9 +6,9 @@ use Illuminate\Database\Eloquent\Builder;
 
 interface Rules
 {
-    public function from(string $date): Builder;
+    public function createdFrom(string $date): Builder;
 
-    public function to(string $date): Builder;
+    public function createdTo(string $date): Builder;
 
     public function modifiedFrom(string $date): Builder;
 

--- a/tests/Dates/DateQueriesTest.php
+++ b/tests/Dates/DateQueriesTest.php
@@ -36,23 +36,23 @@ class DateQueriesTest extends TestCase
     /** @test */
     public function should_retrieve_all_records_from_a_given_date(): void
     {
-        $this->dateRules->shouldReceive('from')->andReturn($this->mock(Builder::class));
+        $this->dateRules->shouldReceive('createdFrom')->andReturn($this->mock(Builder::class));
 
-        $this->dateQueries->from('2023-05-10');
+        $this->dateQueries->createdFrom('2023-05-10');
 
         $this->dateRules->shouldHaveReceived('new')->once()->with($this->dateQueries);
-        $this->dateRules->shouldHaveReceived('from')->once()->with('2023-05-10');
+        $this->dateRules->shouldHaveReceived('createdFrom')->once()->with('2023-05-10');
     }
 
     /** @test */
     public function should_retrieve_all_records_to_a_given_date(): void
     {
-        $this->dateRules->shouldReceive('to')->andReturn($this->mock(Builder::class));
+        $this->dateRules->shouldReceive('createdTo')->andReturn($this->mock(Builder::class));
 
-        $this->dateQueries->to('2023-01-07');
+        $this->dateQueries->createdTo('2023-01-07');
 
         $this->dateRules->shouldHaveReceived('new')->once()->with($this->dateQueries);
-        $this->dateRules->shouldHaveReceived('to')->once()->with('2023-01-07');
+        $this->dateRules->shouldHaveReceived('createdTo')->once()->with('2023-01-07');
     }
 
     /** @test */

--- a/tests/Dates/DateRulesTest.php
+++ b/tests/Dates/DateRulesTest.php
@@ -35,13 +35,13 @@ class DateRulesTest extends TestCase
     /** @test */
     public function should_retrieve_all_records_from_a_given_date(): void
     {
-        $this->assertEquals(4, $this->getDateRules()->from('2023-05-10')->count());
+        $this->assertEquals(4, $this->getDateRules()->createdFrom('2023-05-10')->count());
     }
 
     /** @test */
     public function should_retrieve_all_records_to_a_given_date(): void
     {
-        $this->assertEquals(1, $this->getDateRules()->to('2023-05-09')->count());
+        $this->assertEquals(1, $this->getDateRules()->createdTo('2023-05-09')->count());
     }
 
     /** @test */

--- a/tests/Dates/DateScopesTest.php
+++ b/tests/Dates/DateScopesTest.php
@@ -36,29 +36,29 @@ class DateScopesTest extends TestCase
     /** @test */
     public function should_retrieve_all_records_from_a_given_date(): void
     {
-        $this->dateRules->shouldReceive('from')->andReturn($this->mock(Builder::class));
+        $this->dateRules->shouldReceive('createdFrom')->andReturn($this->mock(Builder::class));
 
-        $this->dateScopes->from('2023-05-10');
+        $this->dateScopes->createdFrom('2023-05-10');
 
         $this->dateRules->shouldHaveReceived('new')->once()->withArgs(
             fn (Builder $arg) => $arg->toSql() === $this->dateScopes->toSql(),
         );
 
-        $this->dateRules->shouldHaveReceived('from')->once()->with('2023-05-10');
+        $this->dateRules->shouldHaveReceived('createdFrom')->once()->with('2023-05-10');
     }
 
     /** @test */
     public function should_retrieve_all_records_to_a_given_date(): void
     {
-        $this->dateRules->shouldReceive('to')->andReturn($this->mock(Builder::class));
+        $this->dateRules->shouldReceive('createdTo')->andReturn($this->mock(Builder::class));
 
-        $this->dateScopes->to('2023-01-07');
+        $this->dateScopes->createdTo('2023-01-07');
 
         $this->dateRules->shouldHaveReceived('new')->once()->withArgs(
             fn (Builder $arg) => $arg->toSql() === $this->dateScopes->toSql(),
         );
 
-        $this->dateRules->shouldHaveReceived('to')->once()->with('2023-01-07');
+        $this->dateRules->shouldHaveReceived('createdTo')->once()->with('2023-01-07');
     }
 
     /** @test */


### PR DESCRIPTION
Avoid conflict with laravel eloquent methods